### PR TITLE
Handling malformed data in an extreme way

### DIFF
--- a/fofa.py
+++ b/fofa.py
@@ -45,6 +45,7 @@ class Fofa:
         self.filename = ""
         self.countryList = []
         self.timestampIndex = 0
+        self.no_new_data_count = 0
         # Fofa-hack 版本号
         self.VERSION_NUM = "2.2.0"
         # 登录最大重试次数
@@ -319,8 +320,12 @@ class Fofa:
             print('[*] 去重结束，最终数据 ' + str(finalint) + ' 条\n')
             exit(0)
         if self.oldLength == len(self.host_set):
-            print("[-] {}节点数据无新增,该节点枯萎".format(index))
-            return
+            self.no_new_data_count += 1
+            if self.no_new_data_count == 2:
+                print("[-] {}节点数据无新增,该节点枯萎".format(index))
+                return
+        else:
+            self.no_new_data_count = 0
 
         if self.fuzz:
             self.fofa_fuzz_spider(search_key, context, index)


### PR DESCRIPTION
当某个日期有且仅有10条数据时，在极端情况下，before语法对于两个临近的日期会返回相同的数据，程序可能会误以为没有新的数据而提前退出。
由于网页显示的总条目数可能与实际情况不符，这里采用一种更粗暴的手段，即无视退出条件再试一次。